### PR TITLE
Handle args to open specific files

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,16 @@ var chrome = {
         cb(true)
       })
     })
+  },
+  fixWhitespace: function(str) {
+    return /\s/g.test(str) ? '"' + str + '"' : str
   }
 }
 
 chrome.isExist(function() {
-  exeq([chrome.getCommand()])
+  exeq([chrome.getCommand()].concat(process.argv.slice(2)).map(chrome.fixWhitespace).join(' '))
+    .catch(function(err) {
+      console.error('Failed to open Google Chrome as intended', err)
+      process.exit(err.code || 13)
+    })
 })

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "author": "afc163 <afc163@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "exeq": "^1.0.0",
-    "plist": "^1.0.1"
+    "exeq": "^2.2.0",
+    "plist": "^1.1.0"
   },
   "maintainers": [
     {


### PR DESCRIPTION
Recently wanted to open animated GIFs from the command line. On Mac, if I do `open some.gif`, it opens in Preview by default and shows each frame separately instead of playing it as an animation. I didn't want to necessarily change the default app for GIFs, so I hunted for an easy way to open the file in Chrome. Of course I can do `open -a "Google Chrome" some.gif` and even define a bash function like `chrome() { open -a "Google Chrome" "$@"; }`, but I found your module and thought it would be a nice, simple addition.

Anyway, with this change you can now do stuff like:

``` sh
$ chrome some.gif
$ chrome "whitespace in name.gif"
$ chrome "whitespace in name.gif" someFile.json some-other-file.html
```

Also updated dependencies. Enjoy!
